### PR TITLE
feat: allow user-provided RPC URL and Etherscan API key

### DIFF
--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -51,6 +51,7 @@ function setCache<T>(key: string, data: T): void {
 export async function getTxTrace(
   chain: string,
   txHash: string,
+  rpcUrl?: string,
 ): Promise<{ result: TxTypes.TxCall }> {
   const cacheKey = `tx:${chain}:${txHash}`
   const cached = getCached<{ result: TxTypes.TxCall }>(cacheKey)
@@ -60,9 +61,10 @@ export async function getTxTrace(
 
   // @ts-ignore
   const cfg = RPC_CONFIG[chain]
-  assert(cfg, `Config for ${chain} is empty`)
+  const url = rpcUrl || cfg?.url
+  assert(url, `RPC URL for ${chain} is empty`)
 
-  const res = await post<any, { result: TxTypes.TxCall }>(cfg.url, {
+  const res = await post<any, { result: TxTypes.TxCall }>(url, {
     jsonrpc: "2.0",
     method: "debug_traceTransaction",
     params: [txHash, { tracer: "callTracer" }],
@@ -143,9 +145,11 @@ export async function batchGetContracts(params: {
 
 export async function getEtherscanContract(
   addr: string,
+  apiKey?: string,
 ): Promise<{ abi: any | null; name: string | null }> {
+  const key = apiKey || import.meta.env.VITE_ETHERSCAN_API_KEY
   const res = await get<{ result: EtherscanContractInfo[] }>(
-    `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${addr}&apikey=${import.meta.env.VITE_ETHERSCAN_API_KEY}`,
+    `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${addr}&apikey=${key}`,
   )
 
   // @ts-ignore

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -145,13 +145,16 @@ export async function batchGetContracts(params: {
 
 export async function getEtherscanContract(
   addr: string,
+  chain: any,
   apiKey?: string,
 ): Promise<{ abi: any | null; name: string | null }> {
   const key = apiKey || import.meta.env.VITE_ETHERSCAN_API_KEY
+  const cfg = RPC_CONFIG[chain as keyof typeof RPC_CONFIG]
+  const chainId = cfg?.chainId
   const res = await get<{ result: EtherscanContractInfo[] }>(
-    `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${addr}&apikey=${key}`,
+    `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getsourcecode&address=${addr}&apikey=${key}`,
   )
-
+  console.log(res)
   // @ts-ignore
   const abi = res?.result?.[0]?.ABI || ""
   // @ts-ignore

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -154,7 +154,7 @@ export async function getEtherscanContract(
   const res = await get<{ result: EtherscanContractInfo[] }>(
     `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getsourcecode&address=${addr}&apikey=${key}`,
   )
-  console.log(res)
+  
   // @ts-ignore
   const abi = res?.result?.[0]?.ABI || ""
   // @ts-ignore

--- a/ui/src/hooks/useGetTrace.tsx
+++ b/ui/src/hooks/useGetTrace.tsx
@@ -399,7 +399,7 @@ export function useGetTrace(params: {
           const addrList = [...addrs.values()]
           const results = await Promise.all(
             addrList.map((addr) =>
-              api.getEtherscanContract(addr, params.etherscanApiKey),
+              api.getEtherscanContract(addr, params.chain, params.etherscanApiKey),
             ),
           )
 

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -14,6 +14,8 @@ export function HomePage() {
     chain: "eth-mainnet",
     // chain: "foundry-test",
     txHash: "",
+    rpcUrl: localStorage.getItem("txgraph_rpc_url") || "",
+    etherscanApiKey: localStorage.getItem("txgraph_etherscan_api_key") || "",
   })
   const [fs, setFiles] = useState<Record<string, FileTypes.File[]>>({})
 
@@ -63,6 +65,11 @@ export function HomePage() {
     } else {
       const txHash = inputs.txHash.trim()
       if (txHash != "") {
+        localStorage.setItem("txgraph_rpc_url", inputs.rpcUrl.trim())
+        localStorage.setItem(
+          "txgraph_etherscan_api_key",
+          inputs.etherscanApiKey.trim(),
+        )
         navigate(`/tx/${inputs.txHash}?chain=${inputs.chain}`)
       }
     }
@@ -112,20 +119,48 @@ export function HomePage() {
               </Button>
             </div>
           ) : (
-            <div className={styles.formGroup}>
-              <label className={styles.label}>transaction hash</label>
-              <div className={styles.inputWrapper}>
+            <>
+              <div className={styles.formGroup}>
+                <label className={styles.label}>transaction hash</label>
+                <div className={styles.inputWrapper}>
+                  <input
+                    className={styles.input}
+                    type="text"
+                    value={inputs.txHash}
+                    onChange={(e) => setTxHash(e.target.value)}
+                    placeholder="0x..."
+                    autoFocus
+                  />
+                  <Button type="submit">explore</Button>
+                </div>
+              </div>
+              <div className={styles.formGroup}>
+                <label className={styles.label}>rpc url (optional)</label>
                 <input
                   className={styles.input}
                   type="text"
-                  value={inputs.txHash}
-                  onChange={(e) => setTxHash(e.target.value)}
-                  placeholder="0x..."
-                  autoFocus
+                  value={inputs.rpcUrl}
+                  onChange={(e) =>
+                    setInputs({ ...inputs, rpcUrl: e.target.value })
+                  }
+                  placeholder="https://..."
                 />
-                <Button type="submit">explore</Button>
               </div>
-            </div>
+              <div className={styles.formGroup}>
+                <label className={styles.label}>
+                  etherscan api key (optional)
+                </label>
+                <input
+                  className={styles.input}
+                  type="text"
+                  value={inputs.etherscanApiKey}
+                  onChange={(e) =>
+                    setInputs({ ...inputs, etherscanApiKey: e.target.value })
+                  }
+                  placeholder="API key"
+                />
+              </div>
+            </>
           )}
         </form>
       </div>

--- a/ui/src/pages/TxPage/index.tsx
+++ b/ui/src/pages/TxPage/index.tsx
@@ -163,12 +163,17 @@ function TxPage() {
   const { txHash = "" } = useParams()
   const [q] = useSearchParams()
   const chain = q.get("chain") || ""
+  const rpcUrl = localStorage.getItem("txgraph_rpc_url") || undefined
+  const etherscanApiKey =
+    localStorage.getItem("txgraph_etherscan_api_key") || undefined
 
   const windowSize = useWindowSizeContext()
   const tracer = useTracerContext()
   const getTrace = useGetTrace({
     txHash,
     chain,
+    rpcUrl,
+    etherscanApiKey,
   })
   const [checked, setChecked] = useState(false)
   const [modal, setModal] = useState<GraphTypes.Hover | null>(null)


### PR DESCRIPTION
Summary

- Add optional RPC URL and Etherscan API key input fields to the home page, allowing users to bring their own RPC provider and Etherscan key
- When a custom RPC URL is provided, it is used for debug_traceTransaction instead of the default config URL
- When an Etherscan API key is provided, contract info (ABI, name) is fetched directly via the Etherscan API instead of the backend postJobs/getJobs flow
- If both fields are left empty, everything works exactly as before (backend RPC + backend contract resolution)
- User-provided values are stored in localStorage (not URL query params) to avoid leaking API keys in browser history, logs, or Referer headers
- Values persist across navigations so users don't have to re-enter them

Changes

- ui/src/api/index.ts — getTxTrace accepts optional rpcUrl; getEtherscanContract accepts optional apiKey
- ui/src/hooks/useGetTrace.tsx — Accepts optional rpcUrl and etherscanApiKey; routes to Etherscan API when key is provided
- ui/src/pages/HomePage.tsx — Two new form inputs (RPC URL, Etherscan API key); saves to localStorage on submit
- ui/src/pages/TxPage/index.tsx — Reads values from localStorage and passes to useGetTrace

Test plan

- Submit with no optional fields — should work as before (backend flow)
- Submit with a custom RPC URL that supports debug_traceTransaction — should fetch trace directly
- Submit with an Etherscan API key — should resolve contract names/ABIs via Etherscan
- Verify API keys are NOT in the URL
- Navigate back to home page — values should persist in the inputs
-Issue faced during testing getting rate-limited by etherscan api

Resolves #4 